### PR TITLE
Changed database to gCloud SQL

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,11 @@
+runtime: nodejs
+env: flex
+service: eureka-api
+env_variables:
+  APPINSIGHTS_INSTRUMENTATIONKEY: 20f0c386-44e4-4eea-97be-2644299652e5
+  EUREKA_ENV: dev
+beta_settings:
+  # The connection name of your instance, available by using
+  # 'gcloud beta sql instances describe [INSTANCE_NAME]' or from
+  # the Instance details page in the Google Cloud Platform Console.
+  cloud_sql_instances: dotted-vim-164110:us-east1:eureka-dev

--- a/config/dev.config.js
+++ b/config/dev.config.js
@@ -1,11 +1,17 @@
+const user = 'roboto'
+const password = '5ffc78b9830ece36adb672e80c54789c'
+const database = 'eureka_dev'
+const instanceName = 'dotted-vim-164110:us-east1:eureka-dev'
+
 module.exports = {
   database: {
     connectionLimit: 10,
-    host: process.env.RDS_HOSTNAME,
-    port: process.env.RDS_PORT,
-    user: process.env.RDS_USERNAME,
-    password: process.env.RDS_PASSWORD,
-    database: process.env.RDS_DB_NAME
+    host: 'localhost',
+    port: 3306,
+    user,
+    password,
+    database,
+    socketPath: `/cloudsql/${instanceName}`
   },
   applicationInsights: {
     iKey: process.env.APPINSIGHTS_INSTRUMENTATIONKEY


### PR DESCRIPTION
Storing plain text password to avoid complicating the deployment. DB is not accessible anyway without Google credentials.